### PR TITLE
feat: add reordering custom hook and component

### DIFF
--- a/src/Reorder/Reorder.js
+++ b/src/Reorder/Reorder.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+function Reorder({ index, reorderObj, children }) {
+  return (
+    <div
+      draggable
+      onDragStart={() => (reorderObj.onCardRef.current = index)}
+      onDragEnter={() => (reorderObj.overCardRef.current = index)}
+      onDragEnd={reorderObj.handleSwap}
+      onDragOver={(e) => e.preventDefault()}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default Reorder;

--- a/src/Reorder/useReorder.js
+++ b/src/Reorder/useReorder.js
@@ -1,10 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 const useReorder = (items, setItems, sectionType) => {
   const onCardRef = useRef(0);
   const overCardRef = useRef(0);
   const timeoutRef = useRef(null);
-  const latestItemsRef = useRef(items);
   const [response, setResponse] = useState(null);
   const [error, setError] = useState(null);
 
@@ -35,7 +34,7 @@ const useReorder = (items, setItems, sectionType) => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ data: latestItemsRef.current }),
+        body: JSON.stringify({ data: items }),
       });
 
       if (!response.ok)
@@ -49,10 +48,6 @@ const useReorder = (items, setItems, sectionType) => {
       console.error(error);
     }
   };
-
-  useEffect(() => {
-    latestItemsRef.current = items;
-  }, [items]);
 
   return {
     response,

--- a/src/Reorder/useReorder.js
+++ b/src/Reorder/useReorder.js
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from "react";
+
+const useReorder = (items, setItems, sectionType) => {
+  const onCardRef = useRef(0);
+  const overCardRef = useRef(0);
+  const timeoutRef = useRef(null);
+  const latestItemsRef = useRef(items);
+  const [response, setResponse] = useState(null);
+  const [error, setError] = useState(null);
+
+  const handleSwap = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    const updatedItems = [...items];
+    const temp = updatedItems[onCardRef.current];
+    updatedItems[onCardRef.current] = updatedItems[overCardRef.current];
+    updatedItems[overCardRef.current] = temp;
+
+    setItems(updatedItems);
+
+    timeoutRef.current = setTimeout(() => {
+      handleRequest(sectionType);
+    }, 3000);
+  };
+
+  const handleRequest = async (sectionType) => {
+    // sectionType must be a valid resume section, e.g. education, experience, skills
+
+    const baseURL = "http://localhost:5000/resume/";
+    try {
+      const response = await fetch(`${baseURL}${sectionType}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ data: latestItemsRef.current }),
+      });
+
+      if (!response.ok)
+        throw new Error(`HTTP error! Status: ${response.status}`);
+
+      const data = await response.json();
+      setResponse(data);
+      setError(null);
+    } catch (error) {
+      setError(error);
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    latestItemsRef.current = items;
+  }, [items]);
+
+  return {
+    response,
+    error,
+    reorderObj: { handleSwap, onCardRef, overCardRef },
+  };
+};
+
+export default useReorder;


### PR DESCRIPTION
Resolves issue #8 

This custom hook and component allows a user to hold and drag one item over another item to swap item positions.

A request will be sent to the backend once the user no longer reorders anything for 3 seconds.

Payload:
```js
{
    data: [...] // updated array
}
```

Usage Example:
```js
import React, { useState } from "react";
import Reorder from "./Reorder/Reorder";
import useReorder from "./Reorder/useReorder";

function Demo() {
  const [items, setItems] = useState([
    "item-1",
    "item-2",
    "item-3",
    "item-4",
    "item-5",
  ]);

  const { response, error, reorderObj } = useReorder(
    items,
    setItems,
    "education"
  );

  return (
    <>
      {items.map((element, index) => (
        <Reorder key={index} index={index} reorderObj={reorderObj}>
          <div key={index}>{element}</div>
        </Reorder>
      ))}
    </>
  );
}

export default Demo;
```

You must import the `useReorder` hook and `Reorder` component. 

The `useReorder` hook requires 3 arguments, `items` must be an array, `setItems` must be the array setter, and `sectionType` must be a string that identifies the resume section (e.g. "education", "experience", and "skills"). The `useReorder` hook returns an object containing `response`, `error`, and `reorderObj`.

The `Reorder` component requires 3 props: `key` and `index` should be assigned an index from the `items` array, and `reorderObj` which takes in `reorderObj` from the `useReorder` hook. The `Reorder` component should wrap the section item component.